### PR TITLE
jsoo 3.3.0 fixes

### DIFF
--- a/pkg/META
+++ b/pkg/META
@@ -31,7 +31,7 @@ package "pdf" (
 package "htmlc" (
   version = "%%VERSION%%"
   description = "Vg's HTML canvas renderer"
-  requires = "vg js_of_ocaml js_of_ocaml.syntax"
+  requires = "vg js_of_ocaml js_of_ocaml.ppx"
   archive(byte) = "vgr_htmlc.cma"
   archive(native) = "vgr_htmlc.cmxa"
   plugin(byte) = "vgr_htmlc.cma"

--- a/src/vgr_htmlc.ml
+++ b/src/vgr_htmlc.ml
@@ -7,6 +7,7 @@
 open Gg
 open Vg
 open Vgr.Private.Data
+open Js_of_ocaml
 
 let str = Format.sprintf
 let warn_dash = "Outline dashes unsupported in this browser"

--- a/src/vgr_htmlc.mli
+++ b/src/vgr_htmlc.mli
@@ -17,7 +17,8 @@
 val screen_resolution : Gg.v2
 (** [screen_resolution] is the screen resolution in pixels per meters. *)
 
-val target : ?resize:bool -> ?resolution:Gg.v2 -> Dom_html.canvasElement Js.t
+val target : ?resize:bool -> ?resolution:Gg.v2
+  -> Js_of_ocaml.Dom_html.canvasElement Js_of_ocaml.Js.t
   -> [`Other] Vg.Vgr.target
 (** [target resize resolution c] is a render target for rendering to the
     canvas element [c].

--- a/test/min_htmlc.ml
+++ b/test/min_htmlc.ml
@@ -11,6 +11,7 @@
 
 open Gg
 open Vg
+open Js_of_ocaml
 
 (* 1. Define your image *)
 

--- a/test/mui.ml
+++ b/test/mui.ml
@@ -4,6 +4,8 @@
    %%NAME%% %%VERSION%%
   ---------------------------------------------------------------------------*)
 
+open Js_of_ocaml
+
 (* Logging functions. *)
 
 module Log = struct

--- a/test/mui.mli
+++ b/test/mui.mli
@@ -56,8 +56,10 @@ module Ui : sig
     'a list ->
     ('a list, 'a list) conf
 
-  val canvas : ?id:string -> unit -> unit t * Dom_html.canvasElement Js.t
-  val canvas_data : Dom_html.canvasElement Js.t -> string
+  val canvas : ?id:string -> unit
+    -> unit t * Js_of_ocaml.Dom_html.canvasElement Js_of_ocaml.Js.t
+  val canvas_data : Js_of_ocaml.Dom_html.canvasElement Js_of_ocaml.Js.t
+    -> string
 (*  val canvas_blob : Dom_html.canvasElement Js.t -> File.blob Js.t *)
 
 

--- a/test/sqc.ml
+++ b/test/sqc.ml
@@ -9,6 +9,7 @@
 
 open Gg
 open Vg
+open Js_of_ocaml
 
 (* [animate] is reusable, it hides browser bureaucracy and jsoo *)
 


### PR DESCRIPTION
Removed js_of_ocaml.syntax package dependency and jsoo deprecation warnings